### PR TITLE
Firefox extension

### DIFF
--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -2,8 +2,7 @@
   "manifest_version": 3,
   "name": "iD Strava Heatmap",
   "description": "Easily overlay the Strava Global Heatmap in your iD editor and gain valuable insights into popular routes and activity patterns.",
-  "version": "0.8.2",
-  "minimum_chrome_version": "88",
+  "version": "0.8.3",
   "permissions": [
     "cookies",
     "declarativeNetRequest"
@@ -13,7 +12,8 @@
     "*://*.openstreetmap.org/*"
   ],
   "background": {
-    "scripts": [ "scripts/background.js" ]
+    "scripts": [ "scripts/background.js" ],
+    "type": "module"
   },
   "content_scripts": [
     {

--- a/scripts/id-script.js
+++ b/scripts/id-script.js
@@ -6,7 +6,7 @@ function resolveStravaHeatmapImagery(type, color) {
     description: `The Strava Heatmap (${type}) shows heat made by aggregated, public activities over the last year.`,
     template: `https://heatmap-external-{switch:a,b,c}.strava.com/tiles/${type.toLowerCase()}/${color.toLowerCase()}/{zoom}/{x}/{y}.png?v=19`,
     terms_url: "https://wiki.openstreetmap.org/wiki/Strava#Data_Permission_-_Allowed_for_tracing!",
-    zoomExtent: [0, 24],
+    zoomExtent: [0, 15],
     overlay: true
   };
 }


### PR DESCRIPTION
Reading through #1, I created this PR so everyone is looking at the same code. This works perfectly for me in FF 128 and 129a. The `zoomExtent` change should fix some of the 403/404 errors, because Strava only provides imagery up to z15, so higher zoom levels were requesting tiles that didn't exist.